### PR TITLE
Add PyPI publication status badge to `README.md`

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish Python Package to PyPI
+name: PyPI Publication
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Format & Style](https://github.com/neuraptic/octopuscl/actions/workflows/format-and-lint.yml/badge.svg?branch=main)](https://github.com/neuraptic/octopuscl/actions/workflows/format-and-lint.yml)
 [![Tests](https://github.com/neuraptic/octopuscl/actions/workflows/run-tests.yml/badge.svg?branch=main)](https://github.com/neuraptic/octopuscl/actions/workflows/run-tests.yml)
+[![PyPI Publication](https://github.com/neuraptic/octopuscl/actions/workflows/publish-to-pypi.yml/badge.svg)](https://github.com/neuraptic/octopuscl/actions/workflows/publish-to-pypi.yml)
 
 </div>
 


### PR DESCRIPTION
**Description**: This PR adds a PyPI publication status badge to the `README.md` file. The badge provides an at-a-glance view of the package's publication status on PyPI.