### PR TITLE
Fix PyPI publication workflow

### DIFF
--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   format-and-lint:
+    name: Format and lint code
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository code

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,14 +5,13 @@ on:
     tags:
       - 'v*'  # Triggers the workflow on version tags like v1.0.0
 
-permissions:
-  id-token: write  # Required for OIDC
-  contents: read   # Needed to access repository content
-
 jobs:
   build-and-publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-
+    environment: PyPI  # Optional but encouraged for better security control
+    permissions:
+      id-token: write  # Mandatory for Trusted Publishing
     steps:
       # Step 1: Checkout the repository
       - name: Checkout code
@@ -24,20 +23,17 @@ jobs:
         with:
           python-version: '3.10'
 
-      # Step 3: Install dependencies
+      # Step 3: Install the dependencies
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build setuptools twine
+          pip install build setuptools
 
       # Step 4: Build the package
-      - name: Build the package
+      - name: Build package
         run: |
           python -m build
 
-      # Step 5: Publish to PyPI
-      - name: Publish to PyPI
-        env:
-          TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
-        run: |
-          twine upload --non-interactive dist/*
+      # Step 5: Publish the package using PyPA action
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   run-tests:
+    name: Run tests
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: test


### PR DESCRIPTION
**Background**: The `publish-to-pypi.yml` workflow is failing because it tries to load user-password credentials instead of using a trusted publisher.

**Fix**: Use PyPA action to support trusted publishers.

**Other Changes**:

- Update workflow job names for consistency.